### PR TITLE
Add support for video recording

### DIFF
--- a/libcamera-rs/Cargo.toml
+++ b/libcamera-rs/Cargo.toml
@@ -5,9 +5,10 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-libcamera-sys = { path = "../libcamera-sys" }
-thiserror = "1.0"
-smallvec = "1.10"
-num_enum = "0.5"
-libc = "0.2"
+bitflags = "2.0.0-rc.2"
 drm-fourcc = "2.2"
+libc = "0.2"
+libcamera-sys = { path = "../libcamera-sys" }
+num_enum = "0.5"
+smallvec = "1.10"
+thiserror = "1.0"

--- a/libcamera-rs/examples/video_capture.rs
+++ b/libcamera-rs/examples/video_capture.rs
@@ -1,0 +1,137 @@
+use std::{fs::OpenOptions, io::Write, process::exit, time::Duration};
+
+use libcamera_rs::{
+    camera::CameraConfigurationStatus,
+    camera_manager::CameraManager,
+    framebuffer::AsFrameBuffer,
+    framebuffer_allocator::{FrameBuffer, FrameBufferAllocator},
+    framebuffer_map::MemoryMappedFrameBuffer,
+    pixel_format::PixelFormat,
+    properties,
+    request::ReuseFlag,
+    stream::StreamRole,
+};
+
+// drm-fourcc does not have MJPEG type yet, construct it from raw fourcc identifier
+const PIXEL_FORMAT_MJPEG: PixelFormat = PixelFormat::new(u32::from_le_bytes([b'M', b'J', b'P', b'G']), 0);
+
+fn main() {
+    let filename = match std::env::args().nth(1) {
+        Some(f) => f,
+        None => {
+            println!("Error: missing file output parameter");
+            println!("Usage: ./video_capture </path/to/output.mjpeg>");
+            exit(1);
+        }
+    };
+
+    let mgr = CameraManager::new().unwrap();
+
+    let cameras = mgr.cameras();
+
+    let cam = cameras.get(0).expect("No cameras found");
+
+    println!(
+        "Using camera: {}",
+        *cam.properties().get::<properties::Model>().unwrap()
+    );
+
+    let mut cam = cam.acquire().expect("Unable to acquire camera");
+
+    // This will generate default configuration for each specified role
+    let mut cfgs = cam.generate_configuration(&[StreamRole::VideoRecording]).unwrap();
+
+    cfgs.get_mut(0).unwrap().set_pixel_format(PIXEL_FORMAT_MJPEG);
+
+    println!("Generated config: {:#?}", cfgs);
+
+    match cfgs.validate() {
+        CameraConfigurationStatus::Valid => println!("Camera configuration valid!"),
+        CameraConfigurationStatus::Adjusted => println!("Camera configuration was adjusted: {:#?}", cfgs),
+        CameraConfigurationStatus::Invalid => panic!("Error validating camera configuration"),
+    }
+
+    // Ensure that pixel format was unchanged
+    assert_eq!(
+        cfgs.get(0).unwrap().get_pixel_format(),
+        PIXEL_FORMAT_MJPEG,
+        "MJPEG is not supported by the camera"
+    );
+
+    cam.configure(&mut cfgs).expect("Unable to configure camera");
+
+    let mut alloc = FrameBufferAllocator::new(&cam);
+
+    // Allocate frame buffers for the stream
+    let cfg = cfgs.get(0).unwrap();
+    let stream = cfg.stream().unwrap();
+    let buffers = alloc.alloc(&stream).unwrap();
+    println!("Allocated {} buffers", buffers.len());
+
+    // Convert FrameBuffer to MemoryMappedFrameBuffer, which allows reading &[u8]
+    let buffers = buffers
+        .into_iter()
+        .map(|buf| MemoryMappedFrameBuffer::new(buf).unwrap())
+        .collect::<Vec<_>>();
+
+    // Create capture requests and attach buffers
+    let reqs = buffers
+        .into_iter()
+        .enumerate()
+        .map(|(i, buf)| {
+            let mut req = cam.create_request(Some(i as u64)).unwrap();
+            req.add_buffer(&stream, buf).unwrap();
+            req
+        })
+        .collect::<Vec<_>>();
+
+    // Completed capture requests are returned as a callback
+    let (tx, rx) = std::sync::mpsc::channel();
+    cam.on_request_completed(move |req| {
+        tx.send(req).unwrap();
+    });
+
+    // TODO: Set `Control::FrameDuration()` here. Blocked on https://github.com/lit-robotics/libcamera-rs/issues/2
+    cam.start(None).unwrap();
+
+    // Enqueue all requests to the camera
+    for req in reqs {
+        println!("Request queued for execution: {req:#?}");
+        cam.queue_request(req).unwrap();
+    }
+
+    let mut file = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(&filename)
+        .expect("Unable to create output file");
+    let mut count = 0;
+    while count < 60 {
+        println!("Waiting for camera request execution");
+        let mut req = rx.recv_timeout(Duration::from_secs(2)).expect("Camera request failed");
+
+        println!("Camera request {:?} completed!", req);
+        println!("Metadata: {:#?}", req.metadata());
+
+        // Get framebuffer for our stream
+        let framebuffer: &MemoryMappedFrameBuffer<FrameBuffer> = req.buffer(&stream).unwrap();
+        println!("FrameBuffer metadata: {:#?}", framebuffer.metadata());
+
+        // MJPEG format has only one data plane containing encoded jpeg data with all the headers
+        let planes = framebuffer.data();
+        let frame_data = planes.get(0).unwrap();
+        // Actual encoded data will be smalled than framebuffer size, its length can be obtained from metadata.
+        let bytes_used = framebuffer.metadata().unwrap().planes().get(0).unwrap().bytes_used as usize;
+
+        file.write(&frame_data[..bytes_used]).unwrap();
+        println!("Written {} bytes to {}", bytes_used, &filename);
+
+        // Recycle the request back to the camera for execution
+        req.reuse(ReuseFlag::ReuseBuffers);
+        cam.queue_request(req).unwrap();
+
+        count += 1;
+    }
+
+    // Everything is cleaned up automatically by Drop implementations
+}

--- a/libcamera-rs/examples/video_capture.rs
+++ b/libcamera-rs/examples/video_capture.rs
@@ -127,7 +127,7 @@ fn main() {
         println!("Written {} bytes to {}", bytes_used, &filename);
 
         // Recycle the request back to the camera for execution
-        req.reuse(ReuseFlag::ReuseBuffers);
+        req.reuse(ReuseFlag::REUSE_BUFFERS);
         cam.queue_request(req).unwrap();
 
         count += 1;

--- a/libcamera-rs/src/request.rs
+++ b/libcamera-rs/src/request.rs
@@ -32,22 +32,14 @@ impl TryFrom<libcamera_request_status_t> for RequestStatus {
 bitflags! {
     /// Flags to control the behaviour of [Request::reuse()].
     pub struct ReuseFlag: u32 {
+        /// Reuse the buffers that were previously added by [Request::add_buffer()].
         const REUSE_BUFFERS = 1 << 0;
     }
 }
 
-// impl From<ReuseFlag> for libcamera_request_reuse_flag_t {
-//     fn from(value: ReuseFlag) -> Self {
-//         match value {
-//             ReuseFlag::Default => libcamera_request_reuse_flag::LIBCAMERA_REQUEST_REUSE_FLAG_DEFAULT,
-//             ReuseFlag::ReuseBuffers => libcamera_request_reuse_flag::LIBCAMERA_REQUEST_REUSE_FLAG_REUSE_BUFFERS,
-//         }
-//     }
-// }
-
 /// A camera capture request.
 ///
-/// Caputre requests are created by [ActiveCamera::create_request()](crate::camera::ActiveCamera::create_request)
+/// Capture requests are created by [ActiveCamera::create_request()](crate::camera::ActiveCamera::create_request)
 /// and scheduled for execution by [ActiveCamera::queue_request()](crate::camera::ActiveCamera::queue_request).
 /// Completed requests are returned by request completed callback (see [ActiveCamera::on_request_completed()](crate::camera::ActiveCamera::on_request_completed))
 /// and can (should) be reused by calling [ActiveCamera::queue_request()](crate::camera::ActiveCamera::queue_request) again.
@@ -81,8 +73,6 @@ impl Request {
     }
 
     /// Returns request metadata, which contains information relevant to the request execution (i.e. capture timestamp).
-    ///
-    /// See [controls](crate::controls) for available items.
     pub fn metadata(&self) -> Immutable<ControlListRef> {
         Immutable(unsafe {
             ControlListRef::from_ptr(NonNull::new(libcamera_request_metadata(self.ptr.as_ptr())).unwrap())
@@ -138,7 +128,7 @@ impl Request {
     ///
     /// Reset the status and controls associated with the request, to allow it to be reused and requeued without destruction. This
     /// function shall be called prior to queueing the request to the camera, in lieu of constructing a new request. The application
-    /// can reuse the buffers that were previously added to the request via [Self::add_buffer()] by setting flags to [ReuseFlag::ReuseBuffers].
+    /// can reuse the buffers that were previously added to the request via [Self::add_buffer()] by setting flags to [ReuseFlag::REUSE_BUFFERS].
     pub fn reuse(&mut self, flags: ReuseFlag) {
         unsafe { libcamera_request_reuse(self.ptr.as_ptr(), flags.bits()) }
     }

--- a/libcamera-rs/src/request.rs
+++ b/libcamera-rs/src/request.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::manual_strip)]
+
 use std::{any::Any, collections::HashMap, io, ptr::NonNull};
 
 use bitflags::bitflags;
@@ -97,14 +99,14 @@ impl Request {
     ///
     /// `T` must be equal to the type used in [Self::add_buffer()], otherwise this will return None.
     pub fn buffer<T: 'static>(&self, stream: &Stream) -> Option<&T> {
-        self.buffers.get(stream).map(|b| b.downcast_ref()).flatten()
+        self.buffers.get(stream).and_then(|b| b.downcast_ref())
     }
 
     /// Returns a mutable reference to the buffer that was attached with [Self::add_buffer()].
     ///
     /// `T` must be equal to the type used in [Self::add_buffer()], otherwise this will return None.
     pub fn buffer_mut<T: 'static>(&mut self, stream: &Stream) -> Option<&mut T> {
-        self.buffers.get_mut(stream).map(|b| b.downcast_mut()).flatten()
+        self.buffers.get_mut(stream).and_then(|b| b.downcast_mut())
     }
 
     /// Returns auto-incrementing sequence number of the capture

--- a/libcamera-rs/src/request.rs
+++ b/libcamera-rs/src/request.rs
@@ -139,7 +139,7 @@ impl Request {
     ///
     /// Reset the status and controls associated with the request, to allow it to be reused and requeued without destruction. This
     /// function shall be called prior to queueing the request to the camera, in lieu of constructing a new request. The application
-    /// can reuse the buffers that were previously added to the request via addBuffer() by setting flags to ReuseBuffers.
+    /// can reuse the buffers that were previously added to the request via [Self::add_buffer()] by setting flags to [ReuseFlag::ReuseBuffers].
     pub fn reuse(&mut self, flags: ReuseFlag) {
         unsafe { libcamera_request_reuse(self.ptr.as_ptr(), flags.into()) }
     }

--- a/libcamera-sys/c_api/request.cpp
+++ b/libcamera-sys/c_api/request.cpp
@@ -38,6 +38,10 @@ libcamera_request_status_t libcamera_request_status(const libcamera_request_t *r
     return request->status();
 }
 
+void libcamera_request_reuse(libcamera_request_t *request, libcamera_request_reuse_flag_t flags) {
+    return request->reuse(flags);
+}
+
 libcamera_framebuffer_t *libcamera_request_buffer_map_get(libcamera_request_buffer_map_t* buffer_map, const libcamera_stream_t *stream) {
 	const auto it = buffer_map->find(stream);
 	if (it == buffer_map->end())

--- a/libcamera-sys/c_api/request.h
+++ b/libcamera-sys/c_api/request.h
@@ -13,6 +13,12 @@ enum libcamera_request_status {
     LIBCAMERA_REQUEST_STATUS_CANCELLED,
 };
 
+enum libcamera_request_reuse_flag {
+    LIBCAMERA_REQUEST_REUSE_FLAG_DEFAULT = 0,
+    LIBCAMERA_REQUEST_REUSE_FLAG_REUSE_BUFFERS = 1 << 0,
+
+};
+
 #ifdef __cplusplus
 #include <libcamera/camera.h>
 
@@ -22,6 +28,7 @@ struct libcamera_request_buffer_map_iter {
 };
 
 typedef libcamera::Request::Status libcamera_request_status_t;
+typedef libcamera::Request::ReuseFlag libcamera_request_reuse_flag_t;
 typedef libcamera::Request libcamera_request_t;
 typedef libcamera::Request::BufferMap libcamera_request_buffer_map_t;
 typedef struct libcamera_request_buffer_map_iter libcamera_request_buffer_map_iter_t;
@@ -29,6 +36,7 @@ typedef struct libcamera_request_buffer_map_iter libcamera_request_buffer_map_it
 extern "C" {
 #else
 typedef enum libcamera_request_status libcamera_request_status_t;
+typedef enum libcamera_request_reuse_flag libcamera_request_reuse_flag_t;
 typedef struct libcamera_request libcamera_request_t;
 typedef struct libcamera_request_buffer_map libcamera_request_buffer_map_t;
 typedef struct libcamera_request_buffer_map_iter libcamera_request_buffer_map_iter_t;
@@ -44,6 +52,7 @@ libcamera_framebuffer_t *libcamera_request_find_buffer(const libcamera_request_t
 uint32_t libcamera_request_sequence(const libcamera_request_t *request);
 uint64_t libcamera_request_cookie(const libcamera_request_t *request);
 libcamera_request_status_t libcamera_request_status(const libcamera_request_t *request);
+void libcamera_request_reuse(libcamera_request_t *request, libcamera_request_reuse_flag_t flags);
 
 // --- libcamera_request_buffer_map_t ---
 libcamera_framebuffer_t *libcamera_request_buffer_map_get(libcamera_request_buffer_map_t* buffer_map, const libcamera_stream_t *stream);


### PR DESCRIPTION
Closes #4 

I've included a new example which just records 20 frames of MJPEG video which doubles as an integration test. That example could be padded out by adding an option for number of frames capture, etc.