### PR TITLE
Refactor controls to use transparent pointers

### DIFF
--- a/libcamera-rs/src/camera.rs
+++ b/libcamera-rs/src/camera.rs
@@ -11,7 +11,7 @@ use std::{
 use libcamera_sys::*;
 
 use crate::{
-    control::{ControlInfoMapRef, ControlListRef, PropertyListRef},
+    control::{ControlInfoMap, ControlList, PropertyList},
     request::Request,
     stream::{StreamConfigurationRef, StreamRole},
     utils::Immutable,
@@ -152,22 +152,20 @@ impl<'d> Camera<'d> {
             .unwrap()
     }
 
-    /// Returns a list of camera controls.
-    ///
-    /// See [controls](crate::controls) for available items.
-    pub fn controls(&self) -> Immutable<ControlInfoMapRef> {
-        Immutable(unsafe {
-            ControlInfoMapRef::from_ptr(NonNull::new(libcamera_camera_controls(self.ptr.as_ptr()).cast_mut()).unwrap())
-        })
+    /// Returns a list of available camera controls and their limit.
+    pub fn controls(&self) -> &ControlInfoMap {
+        unsafe {
+            ControlInfoMap::from_ptr(NonNull::new(libcamera_camera_controls(self.ptr.as_ptr()).cast_mut()).unwrap())
+        }
     }
 
     /// Returns a list of camera properties.
     ///
     /// See [properties](crate::properties) for available items.
-    pub fn properties(&self) -> Immutable<PropertyListRef> {
-        Immutable(unsafe {
-            PropertyListRef::from_ptr(NonNull::new(libcamera_camera_properties(self.ptr.as_ptr()).cast_mut()).unwrap())
-        })
+    pub fn properties(&self) -> &PropertyList {
+        unsafe {
+            PropertyList::from_ptr(NonNull::new(libcamera_camera_properties(self.ptr.as_ptr()).cast_mut()).unwrap())
+        }
     }
 
     /// Generates default camera configuration for the given [StreamRole]s.
@@ -304,8 +302,8 @@ impl<'d> ActiveCamera<'d> {
     /// Starts camera capture session.
     ///
     /// Once started, [ActiveCamera::queue_request()] is permitted and camera configuration can no longer be changed.
-    pub fn start(&mut self, controls: Option<ControlListRef>) -> io::Result<()> {
-        let ctrl_ptr = controls.map(|c| c.ptr.as_ptr()).unwrap_or(core::ptr::null_mut());
+    pub fn start(&mut self, controls: Option<&ControlList>) -> io::Result<()> {
+        let ctrl_ptr = controls.map(|c| c.ptr()).unwrap_or(core::ptr::null_mut());
         let ret = unsafe { libcamera_camera_start(self.ptr.as_ptr(), ctrl_ptr) };
         if ret < 0 {
             Err(io::Error::from_raw_os_error(ret))

--- a/libcamera-rs/src/control.rs
+++ b/libcamera-rs/src/control.rs
@@ -56,7 +56,7 @@ impl ControlInfoMap {
 #[repr(transparent)]
 pub struct ControlList(libcamera_control_list_t);
 
-unsafe impl UniquePtrTarget for ControlList {
+impl UniquePtrTarget for ControlList {
     unsafe fn ptr_new() -> *mut Self {
         libcamera_control_list_create() as *mut Self
     }
@@ -191,7 +191,7 @@ impl<'d> IntoIterator for &'d PropertyList {
     }
 }
 
-impl<'d> core::fmt::Debug for PropertyList {
+impl core::fmt::Debug for PropertyList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut map = f.debug_map();
         for (id, val) in self.into_iter() {

--- a/libcamera-rs/src/control.rs
+++ b/libcamera-rs/src/control.rs
@@ -92,7 +92,7 @@ impl ControlList {
     /// Sets control value.
     ///
     /// This can fail if control is not supported by the camera, but due to libcamera API limitations an error will not be returned.
-    /// Use [ControlListRef::get] if you need to ensure that value was set.
+    /// Use [ControlList::get] if you need to ensure that value was set.
     pub fn set<C: Control>(&mut self, val: C) -> Result<(), ControlError> {
         let ctrl_val: ControlValue = val.into();
 
@@ -163,7 +163,7 @@ impl PropertyList {
     /// Sets property value.
     ///
     /// This can fail if property is not supported by the camera, but due to libcamera API limitations an error will not be returned.
-    /// Use [PropertyListRef::get] if you need to ensure that value was set.
+    /// Use [PropertyList::get] if you need to ensure that value was set.
     pub fn set<C: Property>(&mut self, val: C) -> Result<(), ControlError> {
         let ctrl_val: ControlValue = val.into();
 

--- a/libcamera-rs/src/request.rs
+++ b/libcamera-rs/src/request.rs
@@ -2,7 +2,7 @@ use std::{any::Any, collections::HashMap, io, ptr::NonNull};
 
 use libcamera_sys::*;
 
-use crate::{control::ControlListRef, framebuffer::AsFrameBuffer, stream::Stream, utils::Immutable};
+use crate::{control::ControlList, framebuffer::AsFrameBuffer, stream::Stream};
 
 /// Status of [Request]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -50,26 +50,22 @@ impl Request {
     /// Returns an immutable reference of request controls.
     ///
     /// See [controls](crate::controls) for available items.
-    pub fn controls(&self) -> Immutable<ControlListRef> {
-        Immutable(unsafe {
-            ControlListRef::from_ptr(NonNull::new(libcamera_request_controls(self.ptr.as_ptr())).unwrap())
-        })
+    pub fn controls(&self) -> &ControlList {
+        unsafe { ControlList::from_ptr(NonNull::new(libcamera_request_controls(self.ptr.as_ptr())).unwrap()) }
     }
 
     /// Returns a mutable reference of request controls.
     ///
     /// See [controls](crate::controls) for available items.
-    pub fn controls_mut(&mut self) -> ControlListRef {
-        unsafe { ControlListRef::from_ptr(NonNull::new(libcamera_request_controls(self.ptr.as_ptr())).unwrap()) }
+    pub fn controls_mut(&mut self) -> &mut ControlList {
+        unsafe { ControlList::from_ptr(NonNull::new(libcamera_request_controls(self.ptr.as_ptr())).unwrap()) }
     }
 
     /// Returns request metadata, which contains information relevant to the request execution (i.e. capture timestamp).
     ///
     /// See [controls](crate::controls) for available items.
-    pub fn metadata(&self) -> Immutable<ControlListRef> {
-        Immutable(unsafe {
-            ControlListRef::from_ptr(NonNull::new(libcamera_request_metadata(self.ptr.as_ptr())).unwrap())
-        })
+    pub fn metadata(&self) -> &ControlList {
+        unsafe { ControlList::from_ptr(NonNull::new(libcamera_request_metadata(self.ptr.as_ptr())).unwrap()) }
     }
 
     /// Attaches framebuffer to the request.

--- a/libcamera-rs/src/utils.rs
+++ b/libcamera-rs/src/utils.rs
@@ -1,4 +1,7 @@
-use std::ops::Deref;
+use std::{
+    ops::{Deref, DerefMut},
+    ptr::NonNull,
+};
 
 /// Provides only an immutable reference to the contained type T.
 ///
@@ -22,5 +25,52 @@ impl<T> Deref for Immutable<T> {
 impl<T: core::fmt::Debug> core::fmt::Debug for Immutable<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("Immutable").field(&self.0).finish()
+    }
+}
+
+/// Trait, which allows type to be used in [UniquePtr]
+pub unsafe trait UniquePtrTarget: Sized {
+    /// Allocates `Self` in the heap and returns pointer
+    unsafe fn ptr_new() -> *mut Self;
+    /// Destroys pointer allocated in `ptr_new()`
+    unsafe fn ptr_drop(ptr: *mut Self);
+}
+
+/// Similar to [Box], but uses custom alloc and drop methods defined in [UniquePtrTarget].
+pub struct UniquePtr<T: UniquePtrTarget> {
+    ptr: NonNull<T>,
+}
+
+impl<T: UniquePtrTarget> UniquePtr<T> {
+    pub fn new() -> Self {
+        Self {
+            ptr: NonNull::new(unsafe { T::ptr_new() }).unwrap(),
+        }
+    }
+}
+
+impl<T: UniquePtrTarget> Deref for UniquePtr<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*(self.ptr.as_ptr() as *const T) }
+    }
+}
+
+impl<T: UniquePtrTarget> DerefMut for UniquePtr<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *(self.ptr.as_mut() as *mut T) }
+    }
+}
+
+impl<T: UniquePtrTarget> Drop for UniquePtr<T> {
+    fn drop(&mut self) {
+        unsafe { T::ptr_drop(self.ptr.as_mut()) }
+    }
+}
+
+impl<T: UniquePtrTarget + core::fmt::Debug> core::fmt::Debug for UniquePtr<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.deref().fmt(f)
     }
 }

--- a/libcamera-rs/src/utils.rs
+++ b/libcamera-rs/src/utils.rs
@@ -29,10 +29,18 @@ impl<T: core::fmt::Debug> core::fmt::Debug for Immutable<T> {
 }
 
 /// Trait, which allows type to be used in [UniquePtr]
-pub unsafe trait UniquePtrTarget: Sized {
-    /// Allocates `Self` in the heap and returns pointer
+pub trait UniquePtrTarget: Sized {
+    /// Allocates `Self` in the heap and returns pointer.
+    ///
+    /// # Safety
+    ///
+    /// Pointer must be deallocated by calling [ptr_drop()] when no longer needed.
     unsafe fn ptr_new() -> *mut Self;
-    /// Destroys pointer allocated in `ptr_new()`
+    /// Destroys pointer allocated in `ptr_new()`.
+    ///
+    /// # Safety
+    ///
+    /// Pointer must have been created by [ptr_new()] and is no longer aliased.
     unsafe fn ptr_drop(ptr: *mut Self);
 }
 
@@ -46,6 +54,12 @@ impl<T: UniquePtrTarget> UniquePtr<T> {
         Self {
             ptr: NonNull::new(unsafe { T::ptr_new() }).unwrap(),
         }
+    }
+}
+
+impl<T: UniquePtrTarget> Default for UniquePtr<T> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/libcamera-sys/c_api/controls.cpp
+++ b/libcamera-sys/c_api/controls.cpp
@@ -37,6 +37,14 @@ enum libcamera_control_type libcamera_property_type(enum libcamera_property_id i
         return LIBCAMERA_CONTROL_TYPE_NONE;
 }
 
+libcamera_control_list_t *libcamera_control_list_create() {
+    return new libcamera::ControlList();
+}
+
+void libcamera_control_list_destroy(libcamera_control_list_t *list) {
+    delete list;
+}
+
 const libcamera_control_value_t *libcamera_control_list_get(libcamera_control_list_t *list, enum libcamera_property_id id) {
     if (list->contains(id)) {
         return &list->get(id);

--- a/libcamera-sys/c_api/controls.h
+++ b/libcamera-sys/c_api/controls.h
@@ -49,6 +49,8 @@ const char *libcamera_property_name(enum libcamera_property_id id);
 enum libcamera_control_type libcamera_property_type(enum libcamera_property_id id);
 
 // --- libcamera_control_list_t ---
+libcamera_control_list_t *libcamera_control_list_create();
+void libcamera_control_list_destroy(libcamera_control_list_t *list);
 const libcamera_control_value_t *libcamera_control_list_get(libcamera_control_list_t *list, enum libcamera_property_id id);
 void libcamera_control_list_set(libcamera_control_list_t *list, enum libcamera_property_id id, const libcamera_control_value_t *val);
 libcamera_control_list_iter_t *libcamera_control_list_iter(libcamera_control_list_t *list);


### PR DESCRIPTION
This refactors reference types with lifetimes (i.e. `ControlListRef<'a>`) into transparent pointers, which can be cast into references.

Important changes:
- `Immutable<ControlListRef<'a>>` becomes `&ControlList`
- `ControlListRef<'a>` becomes `&mut ControlList`
- `ControlList` can only exist as a reference so new lists are created with `ControlList::new() -> UniquePtr<ControlList>`. `UniquePtr<T>` implements `Deref<Target = T>`.

Fixes #2