### PR TITLE
Fix ci warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,4 @@
-on:
-  push:
-    paths-ignore:
-      - .gitignore
-      - "*.md"
-  pull_request:
-    paths-ignore:
-      - .gitignore
-      - "*.md"
+on: [push, pull_request]
 
 name: CI
 
@@ -37,10 +29,13 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
+          components: clippy, rustfmt
       - name: Build
         run: cargo build
       - name: Test
         run: cargo test
+      - name: Clippy
+        run: cargo clippy
       - name: Generate docs
         env:
           RUSTFLAGS: "-Dwarnings"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,8 @@ jobs:
         run: cargo build
       - name: Test
         run: cargo test
+      - name: Format
+        run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy
       - name: Generate docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,24 +34,17 @@ jobs:
           meson build -Dipas=vimc -Dpipelines=vimc
           sudo ninja -C build install
       - name: Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+        run: cargo build
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
       - name: Generate docs
-        uses: actions-rs/cargo@v1
         env:
           RUSTFLAGS: "-Dwarnings"
-        with:
-          command: doc
-          args: --no-deps --lib
+        run: cargo doc --no-deps --lib
       - name: Upload docs artifact
         if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install libcamera
         if: steps.cache-libcamera.outputs.cache-hit != 'true'
         run: |
@@ -68,7 +68,7 @@ jobs:
           name: docs
           path: .
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v3
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,12 @@
 on:
   push:
-    branches: [main]
+    paths-ignore:
+      - .gitignore
+      - "*.md"
   pull_request:
-    branches: [main]
+    paths-ignore:
+      - .gitignore
+      - "*.md"
 
 name: CI
 


### PR DESCRIPTION
This fixes the CI warnings by updating some the actions and replacing the action-rs actions due to them all being abandoned. 

I used the dtolnay/rust-toolchain for installing rust since that seems to be the most popular option that was recommended in the action-rs repos. 

For the normal cargo commands it doesnt seem like there is any alternative but luckily this isnt doing much so there was no need for a replacement for that so this is just calling cargo directly.

I also updated the on conditions so it will run the build and test on all branches and PR except for .gitignore/readme changes so its possible to easily debug if a commit is broken without submitting a PR to main.