### PR TITLE
Add error handling for queuing functions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
           # Use only VIMC for faster builds
           meson build -Dipas=vimc -Dpipelines=vimc
           sudo ninja -C build install
+          sudo ldconfig
       - name: Rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/libcamera-rs/src/request.rs
+++ b/libcamera-rs/src/request.rs
@@ -47,7 +47,7 @@ bitflags! {
 /// and can (should) be reused by calling [ActiveCamera::queue_request()](crate::camera::ActiveCamera::queue_request) again.
 pub struct Request {
     pub(crate) ptr: NonNull<libcamera_request_t>,
-    buffers: HashMap<Stream, Box<dyn Any + 'static>>,
+    pub(crate) buffers: HashMap<Stream, Box<dyn Any + 'static>>,
 }
 
 impl Request {


### PR DESCRIPTION
Following on from discussions in #10, this PR demonstrates a possible implementation of improved error handling, focusing just on one group of errors at present - those returned by `libcamera_camera_queue_request`.

There's a couple of ways of doing this, depending on how much one wants to read into the `libcamera` code.

The simplest solution is just to map all error numbers to a rust enum, e.g.

```rust
#[derive(Debug, thiserror::Error)]
pub enum LibcameraError {
    #[error("No device found")]
    ENODEV,
    #[error("Access error")]
    EACCES,
    #[error(transparent)]
    Unexpected(#[from] io::Error),
    // etc
}

// then map return codes to rust errors

let ret = libcamera_camera_queue_request(req);
match ret {
    0 => Ok(()),
    v if v == -libc::ENODEV => Err(LibcameraError::ENODEV),
    v if c == -libc......
    // catch all
    v => Err(LibcameraError::Unexpected(io::Error::from_raw_os_error(v)))
}
```

That would still be better than just returning an `io::Error` which would need to be interrogated with `io::Error.kind()` to yield the particular type.

In the pull request, I've demonstrated a fuller approach which gives specific reasons for why the code produced an error \but\ at the expense of reading through the `libcamera` C code and following all the error paths.

I've be interested to hear thoughts on how I've implemented it in the PR versus any other preferred way.