### PR TITLE
enable `rust_2018_idoms`-lint as warning and fix issues

### DIFF
--- a/libcamera-rs/src/camera.rs
+++ b/libcamera-rs/src/camera.rs
@@ -196,7 +196,9 @@ impl<'d> Drop for Camera<'d> {
 }
 
 extern "C" fn camera_request_completed_cb(ptr: *mut core::ffi::c_void, req: *mut libcamera_request_t) {
-    let mut state = unsafe { &*(ptr as *const Mutex<ActiveCameraState<'_>>) }.lock().unwrap();
+    let mut state = unsafe { &*(ptr as *const Mutex<ActiveCameraState<'_>>) }
+        .lock()
+        .unwrap();
     let req = state.requests.remove(&req).unwrap();
 
     if let Some(cb) = &mut state.request_completed_cb {

--- a/libcamera-rs/src/camera_manager.rs
+++ b/libcamera-rs/src/camera_manager.rs
@@ -30,7 +30,7 @@ impl CameraManager {
     }
 
     /// Enumerates cameras within the system.
-    pub fn cameras(&self) -> CameraList {
+    pub fn cameras(&self) -> CameraList<'_> {
         unsafe { CameraList::from_ptr(NonNull::new(libcamera_camera_manager_cameras(self.ptr.as_ptr())).unwrap()) }
     }
 }
@@ -70,7 +70,7 @@ impl<'d> CameraList<'d> {
     /// Returns camera at a given index.
     ///
     /// Returns [None] if index is out of range of available cameras.
-    pub fn get(&self, index: usize) -> Option<Camera> {
+    pub fn get(&self, index: usize) -> Option<Camera<'_>> {
         let cam_ptr = unsafe { libcamera_camera_list_get(self.ptr.as_ptr(), index as _) };
         NonNull::new(cam_ptr).map(|p| unsafe { Camera::from_ptr(p) })
     }

--- a/libcamera-rs/src/framebuffer.rs
+++ b/libcamera-rs/src/framebuffer.rs
@@ -209,7 +209,7 @@ impl<'d> FrameBufferPlanesRef<'d> {
     }
 
     /// Returns framebuffer plane at a given index
-    pub fn get(&self, index: usize) -> Option<Immutable<FrameBufferPlaneRef>> {
+    pub fn get(&self, index: usize) -> Option<Immutable<FrameBufferPlaneRef<'_>>> {
         if index >= self.len() {
             None
         } else {
@@ -274,7 +274,7 @@ pub trait AsFrameBuffer: Send {
     /// Returns framebuffer metadata information.
     ///
     /// Only available after associated [Request](crate::request::Request) has completed.
-    fn metadata(&self) -> Option<Immutable<FrameMetadataRef>> {
+    fn metadata(&self) -> Option<Immutable<FrameMetadataRef<'_>>> {
         let ptr = NonNull::new(unsafe { libcamera_framebuffer_metadata(self.ptr().as_ptr()) }.cast_mut()).unwrap();
         if unsafe { libcamera_frame_metadata_status(ptr.as_ptr()) } != u32::MAX {
             Some(unsafe { Immutable(FrameMetadataRef::from_ptr(ptr)) })
@@ -284,7 +284,7 @@ pub trait AsFrameBuffer: Send {
     }
 
     /// Provides access to framebuffer data by exposing file descriptors, offsets and lengths of the planes.
-    fn planes(&self) -> Immutable<FrameBufferPlanesRef> {
+    fn planes(&self) -> Immutable<FrameBufferPlanesRef<'_>> {
         unsafe {
             Immutable(FrameBufferPlanesRef::from_ptr(
                 NonNull::new(libcamera_framebuffer_planes(self.ptr().as_ptr()).cast_mut()).unwrap(),

--- a/libcamera-rs/src/framebuffer_allocator.rs
+++ b/libcamera-rs/src/framebuffer_allocator.rs
@@ -21,7 +21,7 @@ pub struct FrameBufferAllocator {
 }
 
 impl FrameBufferAllocator {
-    pub fn new(cam: &Camera) -> Self {
+    pub fn new(cam: &Camera<'_>) -> Self {
         Self {
             inner: Arc::new(FrameBufferAllocatorInstance {
                 ptr: NonNull::new(unsafe { libcamera_framebuffer_allocator_create(cam.ptr.as_ptr()) }).unwrap(),

--- a/libcamera-rs/src/lib.rs
+++ b/libcamera-rs/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(rust_2018_idioms)]
+
 pub mod camera;
 pub mod camera_manager;
 pub mod control;

--- a/libcamera-rs/src/request.rs
+++ b/libcamera-rs/src/request.rs
@@ -61,7 +61,7 @@ impl Request {
     /// Returns an immutable reference of request controls.
     ///
     /// See [controls](crate::controls) for available items.
-    pub fn controls(&self) -> Immutable<ControlListRef> {
+    pub fn controls(&self) -> Immutable<ControlListRef<'_>> {
         Immutable(unsafe {
             ControlListRef::from_ptr(NonNull::new(libcamera_request_controls(self.ptr.as_ptr())).unwrap())
         })
@@ -70,12 +70,12 @@ impl Request {
     /// Returns a mutable reference of request controls.
     ///
     /// See [controls](crate::controls) for available items.
-    pub fn controls_mut(&mut self) -> ControlListRef {
+    pub fn controls_mut(&mut self) -> ControlListRef<'_> {
         unsafe { ControlListRef::from_ptr(NonNull::new(libcamera_request_controls(self.ptr.as_ptr())).unwrap()) }
     }
 
     /// Returns request metadata, which contains information relevant to the request execution (i.e. capture timestamp).
-    pub fn metadata(&self) -> Immutable<ControlListRef> {
+    pub fn metadata(&self) -> Immutable<ControlListRef<'_>> {
         Immutable(unsafe {
             ControlListRef::from_ptr(NonNull::new(libcamera_request_metadata(self.ptr.as_ptr())).unwrap())
         })

--- a/libcamera-rs/src/stream.rs
+++ b/libcamera-rs/src/stream.rs
@@ -157,7 +157,7 @@ impl<'d> StreamConfigurationRef<'d> {
     }
 
     /// Returns a list of available stream formats for this configuration.
-    pub fn formats(&self) -> StreamFormatsRef {
+    pub fn formats(&self) -> StreamFormatsRef<'_> {
         unsafe {
             StreamFormatsRef::from_ptr(
                 NonNull::new(libcamera_stream_configuration_formats(self.ptr.as_ptr()).cast_mut()).unwrap(),


### PR DESCRIPTION
as extensively discussed in rust-lang/rust#91639, elided lifetimes in paths should be visible and can lead to confusion if they are omitted. The `rust_2018_idoms` warning should therefore generally be enabled at crate-level.

An example is something like

```rust
struct SimpleCamera<'a> {
    camera: ActiveCamera<'a>,
}

impl<'a> SimpleCamera<'a> {
    fn new() -> anyhow::Result<Self> {
        let manager = CameraManager::new()?;

        let cameras = manager.cameras();
        let camera = cameras.get(0).unwrap();

        let active_camera = camera.acquire()?;

        Ok(Self {
            camera: active_camera,
        })
    }
}
```

where you might confused why this isn't working, only looking at the return types of `CameraManager::cameras()` and `Camera::acquire()` (which suggest that you get a completely owned value, i.e. no lifetimes and references).

This PR is gonna clash with #6, so I guess #6 should be merged first.