### PR TITLE
Add rustfmt options and format codebase

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install libcamera
-        if: steps.cache-libcamera.outputs.cache-hit != 'true'
         run: |
           sudo pip3 install meson
           sudo apt-get -y install libyaml-dev python3-yaml python3-ply python3-jinja2 ninja-build clang
@@ -34,8 +33,6 @@ jobs:
         run: cargo build
       - name: Test
         run: cargo test
-      - name: Format
-        run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy -- -D warnings
       - name: Generate docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          components: clippy, rustfmt
+          components: clippy
       - name: Build
         run: cargo build
       - name: Test
@@ -37,21 +37,30 @@ jobs:
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy
-        run: cargo clippy
+        run: cargo clippy -- -D warnings
       - name: Generate docs
-        env:
-          RUSTFLAGS: "-Dwarnings"
-        run: cargo doc --no-deps --lib
+        run: cargo doc --no-deps --lib -- -D warnings
       - name: Upload docs artifact
         if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v3
         with:
           name: docs
           path: target/doc
+
+  rustfmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
   docs:
     name: Publish docs
     runs-on: ubuntu-latest
-    needs: build_and_test
+    needs: [build_and_test, rustfmt]
     environment:
       name: github-pages
       url: ${{steps.deployment.outputs.page_url}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,9 @@ jobs:
       - name: Clippy
         run: cargo clippy -- -D warnings
       - name: Generate docs
-        run: cargo doc --no-deps --lib -- -D warnings
+        env:
+          RUSTFLAGS: "-Dwarnings"
+        run: cargo doc --no-deps --lib
       - name: Upload docs artifact
         if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,9 +25,8 @@ jobs:
           meson build -Dipas=vimc -Dpipelines=vimc
           sudo ninja -C build install
       - name: Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: clippy
       - name: Build
         run: cargo build
@@ -49,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
       - run: cargo fmt --all --check

--- a/libcamera-rs/src/camera.rs
+++ b/libcamera-rs/src/camera.rs
@@ -141,7 +141,8 @@ impl<'d> Camera<'d> {
     /// ID of the camera.
     ///
     /// This usually contains hardware path within the system and is not human-friendly.
-    /// Use [properties::Model](crate::properties::Model) from [Camera::properties()] to obtain a human readable identification instead.
+    /// Use [properties::Model](crate::properties::Model) from [Camera::properties()] to obtain a human readable
+    /// identification instead.
     pub fn id(&self) -> &str {
         unsafe { CStr::from_ptr(libcamera_camera_id(self.ptr.as_ptr())) }
             .to_str()
@@ -248,9 +249,11 @@ impl<'d> ActiveCamera<'d> {
 
     /// Sets a callback for completed camera requests.
     ///
-    /// Callback is executed in the libcamera thread context so it is best to setup a channel to send all requests for processing elsewhere.
+    /// Callback is executed in the libcamera thread context so it is best to setup a channel to send all requests for
+    /// processing elsewhere.
     ///
-    /// Only one callback can be set at a time. If there was a previously set callback, it will be discarded when setting a new one.
+    /// Only one callback can be set at a time. If there was a previously set callback, it will be discarded when
+    /// setting a new one.
     pub fn on_request_completed(&mut self, cb: impl FnMut(Request) + Send + 'd) {
         let mut state = self.state.lock().unwrap();
         state.request_completed_cb = Some(Box::new(cb));
@@ -270,18 +273,20 @@ impl<'d> ActiveCamera<'d> {
 
     /// Creates a capture [`Request`].
     ///
-    /// To perform a capture, it must firstly be initialized by attaching a framebuffer with [Request::add_buffer()] and then queued
-    /// for execution by [ActiveCamera::queue_request()].
+    /// To perform a capture, it must firstly be initialized by attaching a framebuffer with [Request::add_buffer()] and
+    /// then queued for execution by [ActiveCamera::queue_request()].
     ///
     /// # Arguments
     ///
-    /// * `cookie` - An optional user-provided u64 identifier that can be used to uniquely identify request in request completed callback.
+    /// * `cookie` - An optional user-provided u64 identifier that can be used to uniquely identify request in request
+    ///   completed callback.
     pub fn create_request(&mut self, cookie: Option<u64>) -> Option<Request> {
         let req = unsafe { libcamera_camera_create_request(self.ptr.as_ptr(), cookie.unwrap_or(0)) };
         NonNull::new(req).map(|p| unsafe { Request::from_ptr(p) })
     }
 
-    /// Queues [`Request`] for execution. Completed requests are returned in request completed callback, set by the `ActiveCamera::on_request_completed()`.
+    /// Queues [`Request`] for execution. Completed requests are returned in request completed callback, set by the
+    /// `ActiveCamera::on_request_completed()`.
     ///
     /// Requests that do not have attached framebuffers are invalid and are rejected without being queued.
     pub fn queue_request(&self, req: Request) -> io::Result<()> {

--- a/libcamera-rs/src/control.rs
+++ b/libcamera-rs/src/control.rs
@@ -79,8 +79,8 @@ impl<'d> ControlListRef<'d> {
 
     /// Sets control value.
     ///
-    /// This can fail if control is not supported by the camera, but due to libcamera API limitations an error will not be returned.
-    /// Use [ControlListRef::get] if you need to ensure that value was set.
+    /// This can fail if control is not supported by the camera, but due to libcamera API limitations an error will not
+    /// be returned. Use [ControlListRef::get] if you need to ensure that value was set.
     pub fn set<C: Control>(&mut self, val: C) -> Result<(), ControlError> {
         let ctrl_val: ControlValue = val.into();
 
@@ -149,8 +149,8 @@ impl<'d> PropertyListRef<'d> {
 
     /// Sets property value.
     ///
-    /// This can fail if property is not supported by the camera, but due to libcamera API limitations an error will not be returned.
-    /// Use [PropertyListRef::get] if you need to ensure that value was set.
+    /// This can fail if property is not supported by the camera, but due to libcamera API limitations an error will not
+    /// be returned. Use [PropertyListRef::get] if you need to ensure that value was set.
     pub fn set<C: Property>(&mut self, val: C) -> Result<(), ControlError> {
         let ctrl_val: ControlValue = val.into();
 

--- a/libcamera-rs/src/framebuffer.rs
+++ b/libcamera-rs/src/framebuffer.rs
@@ -263,8 +263,8 @@ impl<'d> Iterator for FrameBufferPlanesRefIterator<'d> {
 pub trait AsFrameBuffer: Send {
     /// Returns raw framebuffer used by libcamera.
     ///
-    /// It is expected that metadata status field is initialized with u32::MAX on a new buffer, which indicates that metadata
-    /// is not yet available. This "hackfix" prevents read of uninitialized data in [Self::metadata()].
+    /// It is expected that metadata status field is initialized with u32::MAX on a new buffer, which indicates that
+    /// metadata is not yet available. This "hackfix" prevents read of uninitialized data in [Self::metadata()].
     ///
     /// # Safety
     ///

--- a/libcamera-rs/src/framebuffer_allocator.rs
+++ b/libcamera-rs/src/framebuffer_allocator.rs
@@ -29,7 +29,8 @@ impl FrameBufferAllocator {
         }
     }
 
-    /// Allocate N buffers for a given stream, where N is equal to [StreamConfigurationRef::get_buffer_count()](crate::stream::StreamConfigurationRef::get_buffer_count).
+    /// Allocate N buffers for a given stream, where N is equal to
+    /// [StreamConfigurationRef::get_buffer_count()](crate::stream::StreamConfigurationRef::get_buffer_count).
     pub fn alloc(&mut self, stream: &Stream) -> io::Result<Vec<FrameBuffer>> {
         let ret = unsafe { libcamera_framebuffer_allocator_allocate(self.inner.ptr.as_ptr(), stream.ptr.as_ptr()) };
         if ret < 0 {
@@ -44,8 +45,9 @@ impl FrameBufferAllocator {
                 .map(|ptr| NonNull::new(ptr.cast_mut()).unwrap())
                 .map(|ptr| {
                     // This is very very unsafe.
-                    // Setting first field of metadata (status) to u32::MAX, which is used as an indication that metadata is unavailable.
-                    // Otherwise all metadata fields are uninitialized and there is no way to detect availability.
+                    // Setting first field of metadata (status) to u32::MAX, which is used as an indication that
+                    // metadata is unavailable. Otherwise all metadata fields are uninitialized and
+                    // there is no way to detect availability.
                     unsafe {
                         libcamera_framebuffer_metadata(ptr.as_ptr())
                             .cast_mut()

--- a/libcamera-rs/src/lib.rs
+++ b/libcamera-rs/src/lib.rs
@@ -11,5 +11,6 @@ pub mod request;
 pub mod stream;
 pub mod utils;
 
+#[rustfmt::skip]
 mod generated;
 pub use generated::*;

--- a/libcamera-rs/src/pixel_format.rs
+++ b/libcamera-rs/src/pixel_format.rs
@@ -15,7 +15,8 @@ impl PixelFormat {
     /// ```rust
     /// use libcamera_rs::pixel_format::PixelFormat;
     /// // Constructs MJPEG pixel format
-    /// const PIXEL_FORMAT_MJPEG: PixelFormat = PixelFormat::new(u32::from_le_bytes([b'M', b'J', b'P', b'G']), 0);
+    /// const PIXEL_FORMAT_MJPEG: PixelFormat =
+    ///     PixelFormat::new(u32::from_le_bytes([b'M', b'J', b'P', b'G']), 0);
     /// ```
     pub const fn new(fourcc: u32, modifier: u64) -> Self {
         Self(libcamera_pixel_format_t { fourcc, modifier })

--- a/libcamera-rs/src/request.rs
+++ b/libcamera-rs/src/request.rs
@@ -43,8 +43,9 @@ bitflags! {
 ///
 /// Capture requests are created by [ActiveCamera::create_request()](crate::camera::ActiveCamera::create_request)
 /// and scheduled for execution by [ActiveCamera::queue_request()](crate::camera::ActiveCamera::queue_request).
-/// Completed requests are returned by request completed callback (see [ActiveCamera::on_request_completed()](crate::camera::ActiveCamera::on_request_completed))
-/// and can (should) be reused by calling [ActiveCamera::queue_request()](crate::camera::ActiveCamera::queue_request) again.
+/// Completed requests are returned by request completed callback (see
+/// [ActiveCamera::on_request_completed()](crate::camera::ActiveCamera::on_request_completed)) and can (should) be
+/// reused by calling [ActiveCamera::queue_request()](crate::camera::ActiveCamera::queue_request) again.
 pub struct Request {
     pub(crate) ptr: NonNull<libcamera_request_t>,
     buffers: HashMap<Stream, Box<dyn Any + 'static>>,
@@ -83,7 +84,8 @@ impl Request {
 
     /// Attaches framebuffer to the request.
     ///
-    /// Buffers can only be attached once. To access framebuffer after executing request use [Self::buffer()] or [Self::buffer_mut()].
+    /// Buffers can only be attached once. To access framebuffer after executing request use [Self::buffer()] or
+    /// [Self::buffer_mut()].
     pub fn add_buffer<T: AsFrameBuffer + Any>(&mut self, stream: &Stream, buffer: T) -> io::Result<()> {
         let ret =
             unsafe { libcamera_request_add_buffer(self.ptr.as_ptr(), stream.ptr.as_ptr(), buffer.ptr().as_ptr()) };
@@ -114,7 +116,8 @@ impl Request {
         unsafe { libcamera_request_sequence(self.ptr.as_ptr()) }
     }
 
-    /// Returns request identifier that was provided in [ActiveCamera::create_request()](crate::camera::ActiveCamera::create_request).
+    /// Returns request identifier that was provided in
+    /// [ActiveCamera::create_request()](crate::camera::ActiveCamera::create_request).
     ///
     /// Returns zero if cookie was not provided.
     pub fn cookie(&self) -> u64 {
@@ -128,9 +131,10 @@ impl Request {
 
     /// Reset the request for reuse.
     ///
-    /// Reset the status and controls associated with the request, to allow it to be reused and requeued without destruction. This
-    /// function shall be called prior to queueing the request to the camera, in lieu of constructing a new request. The application
-    /// can reuse the buffers that were previously added to the request via [Self::add_buffer()] by setting flags to [ReuseFlag::REUSE_BUFFERS].
+    /// Reset the status and controls associated with the request, to allow it to be reused and requeued without
+    /// destruction. This function shall be called prior to queueing the request to the camera, in lieu of
+    /// constructing a new request. The application can reuse the buffers that were previously added to the request
+    /// via [Self::add_buffer()] by setting flags to [ReuseFlag::REUSE_BUFFERS].
     pub fn reuse(&mut self, flags: ReuseFlag) {
         unsafe { libcamera_request_reuse(self.ptr.as_ptr(), flags.bits()) }
     }

--- a/libcamera-rs/src/stream.rs
+++ b/libcamera-rs/src/stream.rs
@@ -147,8 +147,9 @@ impl<'d> StreamConfigurationRef<'d> {
 
     /// Returns initialized [Stream] for this configuration.
     ///
-    /// Stream is only available once this configuration is applied with [ActiveCamera::configure()](crate::camera::ActiveCamera::configure).
-    /// It is invalidated if camera is reconfigured.
+    /// Stream is only available once this configuration is applied with
+    /// [ActiveCamera::configure()](crate::camera::ActiveCamera::configure). It is invalidated if camera is
+    /// reconfigured.
     pub fn stream(&self) -> Option<Stream> {
         let stream = unsafe { libcamera_stream_configuration_stream(self.ptr.as_ptr()) };
         // Stream is valid after camera->configure(), but might be invalidated after following reconfigurations.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,7 @@
-max_width=120
+unstable_features = true
+max_width = 120
+comment_width = 120
+wrap_comments = true
+format_code_in_doc_comments = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"


### PR DESCRIPTION
Without wishing to bikeshed too much, I think adding a couple of extra options to `rustfmt.toml` can be quite useful as the project grows. Mainly I've added import sorting and comment formatting (which matches the width of the lines of source code). I've ignored the generated modules for now.

To run on the command line, this needs `cargo +nightly fmt` if your default toolchain is `stable`, but note that it doesn't mean `nightly` is required to build the library or for any other reason.

To appease VScode, one can add 

```json
"rust-analyzer.rustfmt.extraArgs": [
    "+nightly"
],
```

to `settings.json`.