### PR TITLE
Error when building C api wrapper: `error: unknown type name 'bool'`

### DIFF
--- a/libcamera-sys/c_api/framebuffer.h
+++ b/libcamera-sys/c_api/framebuffer.h
@@ -1,6 +1,7 @@
 #ifndef __LIBCAMERA_C_FRAMEBUFFER__
 #define __LIBCAMERA_C_FRAMEBUFFER__
 
+#include <stdbool.h>
 #include <stdint.h>
 
 enum libcamera_frame_metadata_status {


### PR DESCRIPTION
On a fresh install (ubuntu 22.04 on x86_64) following all the standard installation instructions for `libcamera` I end up with an error when rust analyzer runs `build.rs`  : `c_api/framebuffer.h:60:1: error: unknown type name 'bool'`.

This appears to be fixed quite simply by adding `#include <stdbool.h>` in the relevant file: https://stackoverflow.com/questions/8133074/error-unknown-type-name-bool