### PR TITLE
Remove unused padding in libcamera_stream_configuration

### DIFF
--- a/libcamera-sys/c_api/stream.h
+++ b/libcamera-sys/c_api/stream.h
@@ -12,7 +12,6 @@ struct libcamera_stream_configuration {
     unsigned int stride;
     unsigned int frame_size;
     unsigned int buffer_count;
-    uint8_t __padding[72];
 };
 
 #ifdef __cplusplus
@@ -21,7 +20,6 @@ struct libcamera_stream_configuration {
 typedef libcamera::StreamFormats libcamera_stream_formats_t;
 
 typedef libcamera::StreamConfiguration libcamera_stream_configuration_t;
-static_assert(sizeof(struct libcamera_stream_configuration) == sizeof(libcamera_stream_configuration_t));
 
 // Read more about this in https://github.com/google/benchmark/issues/552
 #ifdef __GNUC__

--- a/libcamera/src/framebuffer_allocator.rs
+++ b/libcamera/src/framebuffer_allocator.rs
@@ -40,7 +40,6 @@ impl FrameBufferAllocator {
                 unsafe { libcamera_framebuffer_allocator_buffers(self.inner.ptr.as_ptr(), stream.ptr.as_ptr()) };
             let len = unsafe { libcamera_framebuffer_list_size(buffers) };
             Ok((0..len)
-                .into_iter()
                 .map(|i| unsafe { libcamera_framebuffer_list_get(buffers, i) })
                 .map(|ptr| NonNull::new(ptr.cast_mut()).unwrap())
                 .map(|ptr| {

--- a/libcamera/src/stream.rs
+++ b/libcamera/src/stream.rs
@@ -71,7 +71,6 @@ impl<'d> StreamFormatsRef<'d> {
         let len = unsafe { libcamera_sizes_size(sizes) } as usize;
 
         (0..len)
-            .into_iter()
             .map(|i| Size::from(unsafe { *libcamera_sizes_at(sizes, i as _) }))
             .collect()
     }


### PR DESCRIPTION
Hi!

I think we should just drop the padding altogether and don't compare the structure size in tests. The primary reason for that is failing `static_assert` on 32-bit architectures (Raspberry Pi Zero for example). It's due to the `std::string` or `std::map` containing pointers to memory that take more 4 bytes vs 8 bytes on 64-bit archs (partially reported in https://github.com/lit-robotics/libcamera-rs/issues/17).

We could introduce a more complicated padding like:
```c
    void *__padding0[6];
    uint8_t __padding1[24];
```

But I don't feel like this approach has any benefit. The Rust code doesn't make any use of that padding space and only uses that struct through a pointer so only the alignment of the important fields matter and this is already checked with `offsetof`.