### PR TITLE
Add logging functions

### DIFF
--- a/libcamera-sys/c_api/logging.cpp
+++ b/libcamera-sys/c_api/logging.cpp
@@ -1,0 +1,28 @@
+#include <iostream>
+#include "logging.h"
+
+int libcamera_log_set_file(const char *path, bool color) {
+    return libcamera::logSetFile(path, color);
+}
+
+int libcamera_log_set_stream(libcamera_logging_stream_t stream, bool color) {
+    std::ostream *ostream = NULL;
+    switch (stream) {
+        case LIBCAMERA_LOGGING_STREAM_STDOUT:
+            ostream = &std::cout;
+        break;
+
+        case LIBCAMERA_LOGGING_STREAM_STDERR:
+            ostream = &std::cerr;
+        break;
+    }
+    return libcamera::logSetStream(ostream, color);
+}
+
+int libcamera_log_set_target(libcamera_logging_target_t target) {
+    return libcamera::logSetTarget(target);
+}
+
+void libcamera_log_set_level(const char *category, const char *level) {
+    libcamera::logSetLevel(category, level);
+}

--- a/libcamera-sys/c_api/logging.h
+++ b/libcamera-sys/c_api/logging.h
@@ -1,0 +1,39 @@
+#ifndef __LIBCAMERA_C_LOGGING__
+#define __LIBCAMERA_C_LOGGING__
+
+#include <stdbool.h>
+
+enum libcamera_logging_target {
+    LIBCAMERA_LOGGING_TARGET_NONE,
+    LIBCAMERA_LOGGING_TARGET_SYSLOG,
+};
+
+enum libcamera_logging_stream {
+    LIBCAMERA_LOGGING_STREAM_STDOUT,
+    LIBCAMERA_LOGGING_STREAM_STDERR,
+};
+
+typedef enum libcamera_logging_stream libcamera_logging_stream_t;
+
+#ifdef __cplusplus
+
+#include <ostream>
+#include <libcamera/logging.h>
+
+typedef libcamera::LoggingTarget libcamera_logging_target_t;
+
+extern "C" {
+#else
+typedef enum libcamera_logging_target libcamera_logging_target_t;
+#endif
+
+int libcamera_log_set_file(const char *path, bool color);
+int libcamera_log_set_stream(libcamera_logging_stream_t stream, bool color);
+int libcamera_log_set_target(libcamera_logging_target_t target);
+void libcamera_log_set_level(const char *category, const char *level);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libcamera/examples/list_cameras.rs
+++ b/libcamera/examples/list_cameras.rs
@@ -1,7 +1,9 @@
-use libcamera::{camera_manager::CameraManager, stream::StreamRole};
+use libcamera::{camera_manager::CameraManager, logging::LoggingLevel, stream::StreamRole};
 
 fn main() {
     let mgr = CameraManager::new().unwrap();
+
+    mgr.log_set_level("Camera", LoggingLevel::Error);
 
     let cameras = mgr.cameras();
 

--- a/libcamera/examples/logging.rs
+++ b/libcamera/examples/logging.rs
@@ -1,0 +1,15 @@
+use libcamera::logging::{log_set_file, log_set_stream, log_set_target, LoggingStream, LoggingTarget};
+
+fn main() {
+    // Disable all logging output
+    log_set_target(LoggingTarget::None).expect("Can't disable logging");
+
+    // Log to syslog
+    log_set_target(LoggingTarget::Syslog).expect("Can't set logging to syslog");
+
+    // Log to a specific file, disable color codes
+    log_set_file("/tmp/libcamera.log", false).expect("Can't set logging to a file");
+
+    // Log to stdout instead of the default stderr
+    log_set_stream(LoggingStream::StdOut, true).expect("Can't set logging to stdout");
+}

--- a/libcamera/src/lib.rs
+++ b/libcamera/src/lib.rs
@@ -8,6 +8,7 @@ pub mod framebuffer;
 pub mod framebuffer_allocator;
 pub mod framebuffer_map;
 pub mod geometry;
+pub mod logging;
 pub mod pixel_format;
 pub mod request;
 pub mod stream;

--- a/libcamera/src/logging.rs
+++ b/libcamera/src/logging.rs
@@ -1,0 +1,79 @@
+use std::{
+    ffi::{CStr, CString},
+    io,
+};
+
+use libcamera_sys::*;
+
+use crate::utils::handle_result;
+
+/// Log destination type.
+#[derive(Copy, Clone, Debug)]
+pub enum LoggingTarget {
+    None,
+    Syslog,
+}
+
+impl From<LoggingTarget> for libcamera_logging_target_t {
+    fn from(value: LoggingTarget) -> Self {
+        match value {
+            LoggingTarget::None => libcamera_logging_target::LIBCAMERA_LOGGING_TARGET_NONE,
+            LoggingTarget::Syslog => libcamera_logging_target::LIBCAMERA_LOGGING_TARGET_SYSLOG,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum LoggingLevel {
+    Debug,
+    Info,
+    Warn,
+    Error,
+    Fatal,
+}
+
+impl From<LoggingLevel> for &'static CStr {
+    fn from(value: LoggingLevel) -> Self {
+        match value {
+            LoggingLevel::Debug => CStr::from_bytes_with_nul(b"DEBUG\0").expect("Static null-terminated string"),
+            LoggingLevel::Info => CStr::from_bytes_with_nul(b"INFO\0").expect("Static null-terminated string"),
+            LoggingLevel::Warn => CStr::from_bytes_with_nul(b"WARN\0").expect("Static null-terminated string"),
+            LoggingLevel::Error => CStr::from_bytes_with_nul(b"ERROR\0").expect("Static null-terminated string"),
+            LoggingLevel::Fatal => CStr::from_bytes_with_nul(b"FATAL\0").expect("Static null-terminated string"),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum LoggingStream {
+    StdOut,
+    StdErr,
+}
+
+impl From<LoggingStream> for libcamera_logging_stream_t {
+    fn from(value: LoggingStream) -> Self {
+        match value {
+            LoggingStream::StdOut => libcamera_logging_stream::LIBCAMERA_LOGGING_STREAM_STDOUT,
+            LoggingStream::StdErr => libcamera_logging_stream::LIBCAMERA_LOGGING_STREAM_STDERR,
+        }
+    }
+}
+
+/// Direct logging to a file.
+pub fn log_set_file(file: &str, color: bool) -> io::Result<()> {
+    let file = CString::new(file).expect("file contains null byte");
+    let ret = unsafe { libcamera_log_set_file(file.as_ptr(), color) };
+    handle_result(ret)
+}
+
+/// Direct logging to a stream.
+pub fn log_set_stream(stream: LoggingStream, color: bool) -> io::Result<()> {
+    let ret = unsafe { libcamera_log_set_stream(stream.into(), color) };
+    handle_result(ret)
+}
+
+/// Set the logging target.
+pub fn log_set_target(target: LoggingTarget) -> io::Result<()> {
+    let ret = unsafe { libcamera_log_set_target(target.into()) };
+    handle_result(ret)
+}

--- a/libcamera/src/utils.rs
+++ b/libcamera/src/utils.rs
@@ -1,4 +1,6 @@
 use std::{
+    ffi::c_int,
+    io,
     ops::{Deref, DerefMut},
     ptr::NonNull,
 };
@@ -86,5 +88,14 @@ impl<T: UniquePtrTarget> Drop for UniquePtr<T> {
 impl<T: UniquePtrTarget + core::fmt::Debug> core::fmt::Debug for UniquePtr<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.deref().fmt(f)
+    }
+}
+
+#[inline]
+pub fn handle_result(ret: c_int) -> io::Result<()> {
+    if ret < 0 {
+        Err(io::Error::from_raw_os_error(ret))
+    } else {
+        Ok(())
     }
 }


### PR DESCRIPTION
Adds the functions to control libcamera logging. Some notes on the implementation:

* `logSetStream` only allows selection from stdout and stderr due to complexity of handling C++ `ostream`
* `libcamera_logging_target` doesn't contain all enum values because the documentation mentions that only those 2 are valid to be passed to `logSetTarget`
* `log_set_level()` is implemented as the `CameraManager` instance method because in my testing I was only be able to see the effect of this function after the creation of `CameraManager`, any calls before that seem to be ignored.
