### PR TITLE
Migrate to v0.1.0 of libcamera

### DIFF
--- a/libcamera-meta/Cargo.toml
+++ b/libcamera-meta/Cargo.toml
@@ -6,4 +6,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 yaml-rust = "0.4"
-indoc = "1.0"
+indoc = "2.0.3"

--- a/libcamera-sys/Cargo.toml
+++ b/libcamera-sys/Cargo.toml
@@ -17,6 +17,6 @@ doctest = false
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.59"
+bindgen = "0.66.1"
 pkg-config = "0.3.26"
 cc = "1.0"

--- a/libcamera-sys/build.rs
+++ b/libcamera-sys/build.rs
@@ -44,7 +44,7 @@ fn main() {
 
     cc::Build::new()
         .cpp(true)
-        .flag("-std=c++20")
+        .flag("-std=c++17")
         .files(c_api_sources)
         .include(libcamera_include_path)
         .compile("camera_c_api");

--- a/libcamera-sys/build.rs
+++ b/libcamera-sys/build.rs
@@ -44,7 +44,7 @@ fn main() {
 
     cc::Build::new()
         .cpp(true)
-        .flag("-std=c++17")
+        .flag("-std=c++20")
         .files(c_api_sources)
         .include(libcamera_include_path)
         .compile("camera_c_api");

--- a/libcamera-sys/c_api/camera.cpp
+++ b/libcamera-sys/c_api/camera.cpp
@@ -1,7 +1,5 @@
 #include "camera.h"
 
-#include <libcamera/libcamera/version.h>
-
 extern "C" {
 
 void libcamera_camera_configuration_destroy(libcamera_camera_configuration_t* config) {
@@ -69,11 +67,7 @@ const libcamera_control_list_t *libcamera_camera_properties(const libcamera_came
 }
 
 libcamera_camera_configuration_t *libcamera_camera_generate_configuration(libcamera_camera_t *cam, const enum libcamera_stream_role *roles, size_t role_count) {
-#if LIBCAMERA_VERSION_MAJOR == 0 && LIBCAMERA_VERSION_MINOR == 0
-    libcamera::StreamRoles roles_vec((libcamera::StreamRole*)roles, (libcamera::StreamRole*)roles + role_count);
-#else
-    libcamera::utils::span roles_vec {(libcamera::StreamRole*)roles, role_count};
-#endif
+    std::vector<libcamera::StreamRole> roles_vec((libcamera::StreamRole*)roles, (libcamera::StreamRole*)roles + role_count);
     return cam->get()->generateConfiguration(roles_vec).release();
 }
 

--- a/libcamera-sys/c_api/camera.cpp
+++ b/libcamera-sys/c_api/camera.cpp
@@ -1,5 +1,7 @@
 #include "camera.h"
 
+#include <libcamera/libcamera/version.h>
+
 extern "C" {
 
 void libcamera_camera_configuration_destroy(libcamera_camera_configuration_t* config) {
@@ -37,7 +39,7 @@ const char *libcamera_camera_id(const libcamera_camera_t *cam) {
 
 libcamera_callback_handle_t *libcamera_camera_request_completed_connect(libcamera_camera_t *cam, libcamera_request_completed_cb_t *callback, void *data) {
     libcamera_callback_handle_t *handle = new libcamera_callback_handle_t {};
-    
+
     cam->get()->requestCompleted.connect(handle, [=](libcamera::Request *request) {
         callback(data, request);
     });
@@ -67,7 +69,11 @@ const libcamera_control_list_t *libcamera_camera_properties(const libcamera_came
 }
 
 libcamera_camera_configuration_t *libcamera_camera_generate_configuration(libcamera_camera_t *cam, const enum libcamera_stream_role *roles, size_t role_count) {
+#if LIBCAMERA_VERSION_MAJOR == 0 && LIBCAMERA_VERSION_MINOR == 0
     libcamera::StreamRoles roles_vec((libcamera::StreamRole*)roles, (libcamera::StreamRole*)roles + role_count);
+#else
+    libcamera::utils::span roles_vec {(libcamera::StreamRole*)roles, role_count};
+#endif
     return cam->get()->generateConfiguration(roles_vec).release();
 }
 

--- a/libcamera-sys/c_api/camera_manager.cpp
+++ b/libcamera-sys/c_api/camera_manager.cpp
@@ -33,15 +33,6 @@ libcamera_camera_t *libcamera_camera_manager_get_id(libcamera_camera_manager_t *
         return new libcamera_camera_t(camera);
 }
 
-libcamera_camera_t *libcamera_camera_manager_get_dev(libcamera_camera_manager_t *mgr, dev_t dev) {
-    auto camera = mgr->get(dev);
-
-    if (camera == nullptr)
-        return NULL;
-    else
-        return new libcamera_camera_t(camera);
-}
-
 const char *libcamera_camera_manager_version(libcamera_camera_manager_t *mgr) {
     return mgr->version().c_str();
 }

--- a/libcamera-sys/c_api/camera_manager.h
+++ b/libcamera-sys/c_api/camera_manager.h
@@ -24,7 +24,6 @@ int libcamera_camera_manager_start(libcamera_camera_manager_t *mgr);
 void libcamera_camera_manager_stop(libcamera_camera_manager_t *mgr);
 libcamera_camera_list_t *libcamera_camera_manager_cameras(const libcamera_camera_manager_t *mgr);
 libcamera_camera_t *libcamera_camera_manager_get_id(libcamera_camera_manager_t *mgr, const char *id);
-libcamera_camera_t *libcamera_camera_manager_get_dev(libcamera_camera_manager_t *mgr, dev_t dev);
 const char *libcamera_camera_manager_version(libcamera_camera_manager_t *mgr);
 
 void libcamera_camera_list_destroy(libcamera_camera_list_t *list);

--- a/libcamera/Cargo.toml
+++ b/libcamera/Cargo.toml
@@ -15,6 +15,6 @@ bitflags = "2.0.0-rc.2"
 drm-fourcc = "2.2"
 libc = "0.2"
 libcamera-sys = { path = "../libcamera-sys", version = "0.2.1" }
-num_enum = "0.5"
+num_enum = "0.6.1"
 smallvec = "1.10"
 thiserror = "1.0"

--- a/libcamera/src/camera.rs
+++ b/libcamera/src/camera.rs
@@ -89,7 +89,7 @@ impl CameraConfiguration {
 
     /// Returns number of streams within camera configuration.
     pub fn len(&self) -> usize {
-        unsafe { libcamera_camera_configuration_size(self.ptr.as_ptr()) as usize }
+        unsafe { libcamera_camera_configuration_size(self.ptr.as_ptr()) }
     }
 
     /// Returns `true` if camera configuration has no streams.

--- a/libcamera/src/camera_manager.rs
+++ b/libcamera/src/camera_manager.rs
@@ -75,7 +75,7 @@ impl<'d> CameraList<'d> {
 
     /// Number of cameras
     pub fn len(&self) -> usize {
-        unsafe { libcamera_camera_list_size(self.ptr.as_ptr()) as usize }
+        unsafe { libcamera_camera_list_size(self.ptr.as_ptr()) }
     }
 
     /// Returns `true` if there are no cameras available

--- a/libcamera/src/control_value.rs
+++ b/libcamera/src/control_value.rs
@@ -208,7 +208,7 @@ impl TryFrom<ControlValue> for String {
 impl ControlValue {
     pub(crate) unsafe fn read(val: NonNull<libcamera_control_value_t>) -> Result<Self, ControlValueError> {
         let ty = unsafe { libcamera_control_value_type(val.as_ptr()) };
-        let num_elements = unsafe { libcamera_control_value_num_elements(val.as_ptr()) } as usize;
+        let num_elements = unsafe { libcamera_control_value_num_elements(val.as_ptr()) };
         let data = unsafe { libcamera_control_value_get(val.as_ptr()) };
 
         use libcamera_control_type::*;

--- a/libcamera/src/stream.rs
+++ b/libcamera/src/stream.rs
@@ -68,7 +68,7 @@ impl<'d> StreamFormatsRef<'d> {
     /// Returns all supported stream [Size]s for a given [PixelFormat].
     pub fn sizes(&self, pixel_format: PixelFormat) -> Vec<Size> {
         let sizes = unsafe { libcamera_stream_formats_sizes(self.ptr.as_ptr(), &pixel_format.0) };
-        let len = unsafe { libcamera_sizes_size(sizes) } as usize;
+        let len = unsafe { libcamera_sizes_size(sizes) };
 
         (0..len)
             .map(|i| Size::from(unsafe { *libcamera_sizes_at(sizes, i as _) }))


### PR DESCRIPTION
I patched your library to support v0.1.0 of libcamera (Released two weeks ago). The patched library is still compatible to v0.0.4 and v0.0.5 of libcamera.