### PR TITLE
Add missing stddef.h include

### DIFF
--- a/libcamera-sys/c_api/framebuffer.h
+++ b/libcamera-sys/c_api/framebuffer.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stddef.h>
 
 enum libcamera_frame_metadata_status {
     LIBCAMERA_FRAME_METADATA_STATUS_SUCCESS,


### PR DESCRIPTION
This was causing bindings generation error on some of our computers. The size_t type appeared to be missing.

Fixes #29 