### PR TITLE
Apply clippy fixes for rust 1.83

### DIFF
--- a/libcamera/src/camera.rs
+++ b/libcamera/src/camera.rs
@@ -130,7 +130,7 @@ pub struct Camera<'d> {
     _phantom: PhantomData<&'d ()>,
 }
 
-impl<'d> Camera<'d> {
+impl Camera<'_> {
     pub(crate) unsafe fn from_ptr(ptr: NonNull<libcamera_camera_t>) -> Self {
         Self {
             ptr,
@@ -188,7 +188,7 @@ impl<'d> Camera<'d> {
     }
 }
 
-impl<'d> Drop for Camera<'d> {
+impl Drop for Camera<'_> {
     fn drop(&mut self) {
         unsafe { libcamera_camera_destroy(self.ptr.as_ptr()) }
     }
@@ -336,13 +336,13 @@ impl<'d> Deref for ActiveCamera<'d> {
     }
 }
 
-impl<'d> DerefMut for ActiveCamera<'d> {
+impl DerefMut for ActiveCamera<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.cam
     }
 }
 
-impl<'d> Drop for ActiveCamera<'d> {
+impl Drop for ActiveCamera<'_> {
     fn drop(&mut self) {
         unsafe {
             libcamera_camera_request_completed_disconnect(self.ptr.as_ptr(), self.request_completed_handle);

--- a/libcamera/src/camera_manager.rs
+++ b/libcamera/src/camera_manager.rs
@@ -65,7 +65,7 @@ pub struct CameraList<'d> {
     _phantom: PhantomData<&'d ()>,
 }
 
-impl<'d> CameraList<'d> {
+impl CameraList<'_> {
     pub(crate) unsafe fn from_ptr(ptr: NonNull<libcamera_camera_list_t>) -> Self {
         Self {
             ptr,
@@ -92,7 +92,7 @@ impl<'d> CameraList<'d> {
     }
 }
 
-impl<'d> Drop for CameraList<'d> {
+impl Drop for CameraList<'_> {
     fn drop(&mut self) {
         unsafe {
             libcamera_camera_list_destroy(self.ptr.as_ptr());

--- a/libcamera/src/control.rs
+++ b/libcamera/src/control.rs
@@ -214,7 +214,7 @@ pub struct ControlListRefIterator<'d> {
     _phantom: PhantomData<&'d ()>,
 }
 
-impl<'d> Iterator for ControlListRefIterator<'d> {
+impl Iterator for ControlListRefIterator<'_> {
     type Item = (u32, ControlValue);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -233,7 +233,7 @@ impl<'d> Iterator for ControlListRefIterator<'d> {
     }
 }
 
-impl<'d> Drop for ControlListRefIterator<'d> {
+impl Drop for ControlListRefIterator<'_> {
     fn drop(&mut self) {
         unsafe { libcamera_control_list_iter_destroy(self.it.as_ptr()) }
     }

--- a/libcamera/src/framebuffer.rs
+++ b/libcamera/src/framebuffer.rs
@@ -79,7 +79,7 @@ pub struct FrameMetadataPlanesIterator<'d> {
     index: usize,
 }
 
-impl<'d> Iterator for FrameMetadataPlanesIterator<'d> {
+impl Iterator for FrameMetadataPlanesIterator<'_> {
     type Item = FrameMetadataPlane;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -97,7 +97,7 @@ pub struct FrameMetadataRef<'d> {
     _phantom: PhantomData<&'d ()>,
 }
 
-impl<'d> FrameMetadataRef<'d> {
+impl FrameMetadataRef<'_> {
     pub(crate) unsafe fn from_ptr(ptr: NonNull<libcamera_frame_metadata_t>) -> Self {
         Self {
             ptr,
@@ -124,7 +124,7 @@ impl<'d> FrameMetadataRef<'d> {
     }
 }
 
-impl<'d> core::fmt::Debug for FrameMetadataRef<'d> {
+impl core::fmt::Debug for FrameMetadataRef<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FrameMetadataRef")
             .field("status", &self.status())
@@ -140,7 +140,7 @@ pub struct FrameBufferPlaneRef<'d> {
     _phantom: PhantomData<&'d ()>,
 }
 
-impl<'d> FrameBufferPlaneRef<'d> {
+impl FrameBufferPlaneRef<'_> {
     pub(crate) unsafe fn from_ptr(ptr: NonNull<libcamera_framebuffer_plane_t>) -> Self {
         Self {
             ptr,
@@ -175,7 +175,7 @@ impl<'d> FrameBufferPlaneRef<'d> {
     }
 }
 
-impl<'d> core::fmt::Debug for FrameBufferPlaneRef<'d> {
+impl core::fmt::Debug for FrameBufferPlaneRef<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FrameBufferPlaneRef")
             .field("fd", &self.fd())
@@ -190,7 +190,7 @@ pub struct FrameBufferPlanesRef<'d> {
     _phantom: PhantomData<&'d ()>,
 }
 
-impl<'d> FrameBufferPlanesRef<'d> {
+impl FrameBufferPlanesRef<'_> {
     pub(crate) unsafe fn from_ptr(ptr: NonNull<libcamera_framebuffer_planes_t>) -> Self {
         Self {
             ptr,
@@ -222,7 +222,7 @@ impl<'d> FrameBufferPlanesRef<'d> {
     }
 }
 
-impl<'d> core::fmt::Debug for FrameBufferPlanesRef<'d> {
+impl core::fmt::Debug for FrameBufferPlanesRef<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut list = f.debug_list();
         for plane in self.into_iter() {

--- a/libcamera/src/logging.rs
+++ b/libcamera/src/logging.rs
@@ -35,11 +35,11 @@ pub enum LoggingLevel {
 impl From<LoggingLevel> for &'static CStr {
     fn from(value: LoggingLevel) -> Self {
         match value {
-            LoggingLevel::Debug => CStr::from_bytes_with_nul(b"DEBUG\0").expect("Static null-terminated string"),
-            LoggingLevel::Info => CStr::from_bytes_with_nul(b"INFO\0").expect("Static null-terminated string"),
-            LoggingLevel::Warn => CStr::from_bytes_with_nul(b"WARN\0").expect("Static null-terminated string"),
-            LoggingLevel::Error => CStr::from_bytes_with_nul(b"ERROR\0").expect("Static null-terminated string"),
-            LoggingLevel::Fatal => CStr::from_bytes_with_nul(b"FATAL\0").expect("Static null-terminated string"),
+            LoggingLevel::Debug => c"DEBUG",
+            LoggingLevel::Info => c"INFO",
+            LoggingLevel::Warn => c"WARN",
+            LoggingLevel::Error => c"ERROR",
+            LoggingLevel::Fatal => c"FATAL",
         }
     }
 }

--- a/libcamera/src/pixel_format.rs
+++ b/libcamera/src/pixel_format.rs
@@ -138,7 +138,7 @@ pub struct PixelFormatsIterator<'d> {
     index: usize,
 }
 
-impl<'d> Iterator for PixelFormatsIterator<'d> {
+impl Iterator for PixelFormatsIterator<'_> {
     type Item = PixelFormat;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/libcamera/src/stream.rs
+++ b/libcamera/src/stream.rs
@@ -50,7 +50,7 @@ pub struct StreamFormatsRef<'d> {
     _phantom: PhantomData<&'d ()>,
 }
 
-impl<'d> StreamFormatsRef<'d> {
+impl StreamFormatsRef<'_> {
     pub(crate) unsafe fn from_ptr(ptr: NonNull<libcamera_stream_formats_t>) -> Self {
         Self {
             ptr,
@@ -81,7 +81,7 @@ impl<'d> StreamFormatsRef<'d> {
     }
 }
 
-impl<'d> core::fmt::Debug for StreamFormatsRef<'d> {
+impl core::fmt::Debug for StreamFormatsRef<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut map = f.debug_map();
         for pixel_format in self.pixel_formats().into_iter() {
@@ -96,7 +96,7 @@ pub struct StreamConfigurationRef<'d> {
     _phantom: PhantomData<&'d ()>,
 }
 
-impl<'d> StreamConfigurationRef<'d> {
+impl StreamConfigurationRef<'_> {
     pub(crate) unsafe fn from_ptr(ptr: NonNull<libcamera_stream_configuration_t>) -> Self {
         Self {
             ptr,
@@ -166,7 +166,7 @@ impl<'d> StreamConfigurationRef<'d> {
     }
 }
 
-impl<'d> core::fmt::Debug for StreamConfigurationRef<'d> {
+impl core::fmt::Debug for StreamConfigurationRef<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("StreamConfigurationRef")
             .field("pixel_format", &self.get_pixel_format())


### PR DESCRIPTION
These were just generated by running

```bash
cargo clippy --fix --lib -p libcamera
```

And resolve the issues that that clippy in rust 1.83 has found