### PR TITLE
Update the version of libcamera to allow ci to build libcamera

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
         run: |
           sudo pip3 install meson
           sudo apt-get -y install libyaml-dev python3-yaml python3-ply python3-jinja2 ninja-build clang
-          git clone https://git.libcamera.org/libcamera/libcamera.git deps/libcamera --branch v0.1.0
+          git clone https://git.libcamera.org/libcamera/libcamera.git deps/libcamera --branch v0.3.2
           cd deps/libcamera
           # Use only VIMC for faster builds
           meson build -Dipas=vimc -Dpipelines=vimc


### PR DESCRIPTION
This MR shows one way to resolve https://github.com/lit-robotics/libcamera-rs/issues/50

The changes in this MR and https://github.com/lit-robotics/libcamera-rs/pull/49 should fix the CI