### PR TITLE
Added SensorConfiguration struct

### DIFF
--- a/libcamera-sys/c_api/camera.cpp
+++ b/libcamera-sys/c_api/camera.cpp
@@ -91,4 +91,28 @@ int libcamera_camera_stop(libcamera_camera_t *cam) {
     return cam->get()->stop();
 }
 
+libcamera_sensor_configuration_t *libcamera_sensor_configuration_create()
+{
+    return new libcamera_sensor_configuration_t();
+}
+
+void libcamera_sensor_configuration_set_bit_depth(libcamera_sensor_configuration_t *config, unsigned int bit_depth)
+{
+    config->bitDepth = bit_depth;
+}
+
+void libcamera_sensor_configuration_set_output_size(libcamera_sensor_configuration_t *config, unsigned int width, unsigned int height)
+{
+    config->outputSize = libcamera::Size(width, height);
+}
+
+void libcamera_camera_set_sensor_configuration(libcamera_camera_configuration_t *config, const libcamera_sensor_configuration_t *sensor_config)
+{
+    config->sensorConfig = *sensor_config;
+}
+
+void libcamera_sensor_configuration_destroy(libcamera_sensor_configuration_t *config) {
+    delete config;
+}
+
 }

--- a/libcamera-sys/c_api/camera.h
+++ b/libcamera-sys/c_api/camera.h
@@ -19,6 +19,7 @@ typedef void libcamera_request_completed_cb_t(void*, libcamera_request_t*);
 #ifdef __cplusplus
 #include <libcamera/camera.h>
 
+typedef libcamera::SensorConfiguration libcamera_sensor_configuration_t;
 typedef libcamera::CameraConfiguration libcamera_camera_configuration_t;
 typedef libcamera::CameraConfiguration::Status libcamera_camera_configuration_status_t;
 typedef std::shared_ptr<libcamera::Camera> libcamera_camera_t;
@@ -27,6 +28,7 @@ extern "C" {
 #else
 typedef enum libcamera_camera_configuration_status libcamera_camera_configuration_status_t;
 typedef struct libcamera_camera_configuration_t libcamera_camera_configuration_t;
+typedef struct libcamera_sensor_configuration_t libcamera_sensor_configuration_t;
 typedef struct libcamera_camera_t libcamera_camera_t;
 #endif
 
@@ -50,6 +52,12 @@ libcamera_request_t *libcamera_camera_create_request(libcamera_camera_t *cam, ui
 int libcamera_camera_queue_request(libcamera_camera_t *cam, libcamera_request_t *request);
 int libcamera_camera_start(libcamera_camera_t *cam, const libcamera_control_list_t *controls);
 int libcamera_camera_stop(libcamera_camera_t *cam);
+
+libcamera_sensor_configuration_t *libcamera_sensor_configuration_create();
+void libcamera_sensor_configuration_destroy(libcamera_sensor_configuration_t *config);
+void libcamera_sensor_configuration_set_bit_depth(libcamera_sensor_configuration_t *config, unsigned int bit_depth);
+void libcamera_sensor_configuration_set_output_size(libcamera_sensor_configuration_t *config, unsigned int width, unsigned int height);
+void libcamera_camera_set_sensor_configuration(libcamera_camera_configuration_t *config, const libcamera_sensor_configuration_t *sensor_config);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
With a certain camera:
```
rpicam-hello --list-cameras
Available cameras
-----------------
0 : imx219 [3280x2464 10-bit RGGB] (/base/axi/pcie@120000/rp1/i2c@88000/imx219@10)
    Modes: 'SRGGB10_CSI2P' : 640x480 [206.65 fps - (1000, 752)/1280x960 crop]
                             1640x1232 [41.85 fps - (0, 0)/3280x2464 crop]
                             1920x1080 [47.57 fps - (680, 692)/1920x1080 crop]
                             3280x2464 [21.19 fps - (0, 0)/3280x2464 crop]
           'SRGGB8' : 640x480 [206.65 fps - (1000, 752)/1280x960 crop]
                      1640x1232 [83.70 fps - (0, 0)/3280x2464 crop]
                      1920x1080 [47.57 fps - (680, 692)/1920x1080 crop]
                      3280x2464 [21.19 fps - (0, 0)/3280x2464 crop]
```
You cannot select exact sensor mode by providing a pixel format. Cause when I set pixel format to RGGB expecting to select `SRGGB8 1640x1232 [83.70 fps - (0, 0)/3280x2464 crop]`  libcamera selects  `'SRGGB10_CSI2P' 1640x1232 [41.85 fps - (0, 0)/3280x2464 crop]` sensor mode cause it's fully compatible in every part (cause both of them are extended to RGGB16).

This struct allows to define a specific sensor configuration and provide it to camera configuration before validate call. It allows user to specify exact sensor mode that needs to be used:

```
        let mut cfgs = camera.generate_configuration(&[StreamRole::Raw])
            .context("generate camera configuration")?;

        let mut sensor_mode = SensorConfiguration::new();
        sensor_mode.set_bit_depth(SENSOR_BIT_DEPTH);
        sensor_mode.set_output_size(FRAME_WIDTH, FRAME_HEIGHT);
        cfgs.set_sensor_configuration(sensor_mode);

        let mut config = cfgs.get_mut(0).unwrap();
        config.set_pixel_format(PIXEL_FORMAT_RAW);
        config.set_size(Size { width: FRAME_WIDTH, height: FRAME_HEIGHT });
        config.set_buffer_count(NUM_BUFFERS);

        match cfgs.validate() {
            CameraConfigurationStatus::Valid => log::debug!("Camera configuration valid!"),
            CameraConfigurationStatus::Adjusted => log::debug!("Camera configuration was adjusted: {:#?}", cfgs),
            CameraConfigurationStatus::Invalid => bail!("Error validating camera configuration"),
        }

```

For my setup it does exactly what I want - select exact sensor mode.