### PR TITLE
Fix build: Add missing include for C `bool` type.

### DIFF
--- a/libcamera-sys/c_api/pixel_format.h
+++ b/libcamera-sys/c_api/pixel_format.h
@@ -1,6 +1,7 @@
 #ifndef __LIBCAMERA_C_PIXEL_FORMAT__
 #define __LIBCAMERA_C_PIXEL_FORMAT__
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 


### PR DESCRIPTION
Unlike C++, `bool` is not a built-in type in C, so requires the `<stdbool.h>` header.

Fxes a build-error:

```
  ./c_api/pixel_format.h:37:1: error: unknown type name 'bool'

  thread 'main' (165738) panicked at ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libcamera-sys-0.6.0/build.rs:76:39:
  Unable to generate bindings: ClangDiagnostic("./c_api/pixel_format.h:37:1: error: unknown type name 'bool'\n")
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```